### PR TITLE
Feature/map-layout 모임 지도 레이아웃 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
         <activity android:name=".ui.postcomposition.PostCompositionActivity" />
         <activity android:name=".ui.settinguserinfo.SettingUserInfoActivity" />
         <activity android:name=".ui.LoginActivity" />
-        <activity android:name=".ui.MapActivity" />
+        <activity android:name=".ui.map.MapActivity" />
         <activity
             android:name=".ui.LauncherActivity"
             android:exported="true">

--- a/app/src/main/java/com/pjm/cours/data/PostRepository.kt
+++ b/app/src/main/java/com/pjm/cours/data/PostRepository.kt
@@ -7,7 +7,7 @@ import com.pjm.cours.util.DateFormat
 import kotlinx.coroutines.tasks.await
 import retrofit2.Response
 
-class PostCompositionRepository(
+class PostRepository(
     private val apiClient: ApiClient,
 ) {
 

--- a/app/src/main/java/com/pjm/cours/data/PostRepository.kt
+++ b/app/src/main/java/com/pjm/cours/data/PostRepository.kt
@@ -42,4 +42,9 @@ class PostRepository(
             )
         )
     }
+
+    suspend fun getPostList(): Response<Map<String, Post>> {
+        val idToken = FirebaseAuth.getInstance().currentUser?.getIdToken(true)?.await()?.token
+        return apiClient.getPosts(idToken)
+    }
 }

--- a/app/src/main/java/com/pjm/cours/data/remote/ApiClient.kt
+++ b/app/src/main/java/com/pjm/cours/data/remote/ApiClient.kt
@@ -11,6 +11,7 @@ import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import retrofit2.http.Body
+import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Query
 
@@ -27,6 +28,11 @@ interface ApiClient {
         @Query("auth") auth: String?,
         @Body user: Post
     ): Response<Map<String, String>>
+
+    @GET("post.json")
+    suspend fun getPosts(
+        @Query("auth") auth: String?
+    ): Response<Map<String, Post>>
 
     companion object {
 

--- a/app/src/main/java/com/pjm/cours/ui/LauncherActivity.kt
+++ b/app/src/main/java/com/pjm/cours/ui/LauncherActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.pjm.cours.CoursApplication
+import com.pjm.cours.ui.map.MapActivity
 import com.pjm.cours.util.Constants.KEY_GOOGLE_ID_TOKEN
 
 class LauncherActivity : AppCompatActivity() {

--- a/app/src/main/java/com/pjm/cours/ui/location/LocationActivity.kt
+++ b/app/src/main/java/com/pjm/cours/ui/location/LocationActivity.kt
@@ -172,6 +172,11 @@ class LocationActivity : AppCompatActivity(), MapView.MapViewEventListener,
         viewModel.endTracking()
     }
 
+    override fun finish() {
+        super.finish()
+        binding.mapView.removeView(mapView)
+    }
+
     private fun createMarker(location: String): MapPOIItem {
         val marker = MapPOIItem()
         marker.itemName = location

--- a/app/src/main/java/com/pjm/cours/ui/map/MapActivity.kt
+++ b/app/src/main/java/com/pjm/cours/ui/map/MapActivity.kt
@@ -1,4 +1,4 @@
-package com.pjm.cours.ui
+package com.pjm.cours.ui.map
 
 import android.content.Intent
 import android.os.Bundle

--- a/app/src/main/java/com/pjm/cours/ui/map/MapActivity.kt
+++ b/app/src/main/java/com/pjm/cours/ui/map/MapActivity.kt
@@ -2,32 +2,174 @@ package com.pjm.cours.ui.map
 
 import android.content.Intent
 import android.os.Bundle
+import android.view.View
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.viewpager2.widget.ViewPager2
+import com.pjm.cours.CoursApplication
 import com.pjm.cours.R
+import com.pjm.cours.data.PostRepository
+import com.pjm.cours.data.model.Post
 import com.pjm.cours.databinding.ActivityMapBinding
 import com.pjm.cours.ui.postcomposition.PostCompositionActivity
+import net.daum.mf.map.api.MapPOIItem
+import net.daum.mf.map.api.MapPoint
+import net.daum.mf.map.api.MapView
+import net.daum.mf.map.api.MapView.MapViewEventListener
+import net.daum.mf.map.api.MapView.POIItemEventListener
 
-class MapActivity : AppCompatActivity() {
+
+class MapActivity : AppCompatActivity(), MapViewEventListener, POIItemEventListener {
 
     private lateinit var binding: ActivityMapBinding
-
+    private val viewModel: MapViewModel by viewModels {
+        MapViewModel.provideFactory(PostRepository(CoursApplication.apiContainer.provideApiClient()))
+    }
+    private lateinit var mapView: MapView
+    private var makerList: List<Post>? = listOf()
+    private var stringList: List<String> = listOf()
+    private val adapter = PreviewAdapter()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityMapBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
+        initMapView()
         setLayout()
+        setObserver()
+    }
+
+    private fun initMapView() {
+        viewModel.getPosts()
+        mapView = MapView(this)
+        mapView.setMapViewEventListener(this)
+        mapView.setPOIItemEventListener(this)
+        binding.mapView.addView(mapView)
     }
 
     private fun setLayout() {
-        binding.appBarPostComposition.setOnMenuItemClickListener { menuItem ->
+        binding.appBarMap.setOnMenuItemClickListener { menuItem ->
             when (menuItem.itemId) {
                 R.id.create_post -> {
-                    startActivity(Intent(this,PostCompositionActivity::class.java))
+                    startActivity(Intent(this, PostCompositionActivity::class.java))
                     true
                 }
                 else -> false
             }
         }
+        binding.viewPagerMap.adapter = adapter
+    }
+
+    private fun setObserver() {
+        viewModel.isCompleted.observe(this) { isCompleted ->
+            if (isCompleted) {
+                makerList = viewModel.postList
+                val markerArr = ArrayList<MapPOIItem>()
+                for (data in makerList!!) {
+                    val marker = MapPOIItem()
+                    marker.mapPoint = MapPoint.mapPointWithGeoCoord(
+                        data.latitude.toDouble(),
+                        data.longitude.toDouble()
+                    )
+                    marker.markerType = MapPOIItem.MarkerType.BluePin
+                    marker.selectedMarkerType = MapPOIItem.MarkerType.RedPin
+                    marker.itemName = data.location
+                    markerArr.add(marker)
+                    mapView.addPOIItem(marker)
+                }
+                stringList = makerList!!.map { it.location }
+                adapter.submitList(stringList)
+                with(binding.viewPagerMap) {
+                    val pageWidth = resources.getDimension(R.dimen.viewpager_item_width)
+                    val pageMargin = resources.getDimension(R.dimen.viewpager_item_margin)
+                    val screenWidth = resources.displayMetrics.widthPixels
+                    val offset = screenWidth - pageWidth - pageMargin
+
+                    offscreenPageLimit = 2
+                    setPageTransformer { page, position ->
+                        page.translationX = position * -offset
+                    }
+                    registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+                        override fun onPageScrolled(
+                            position: Int,
+                            positionOffset: Float,
+                            positionOffsetPixels: Int
+                        ) {
+                            super.onPageScrolled(position, positionOffset, positionOffsetPixels)
+                        }
+
+                        override fun onPageSelected(position: Int) {
+                            super.onPageSelected(position)
+                            mapView.selectPOIItem(mapView.poiItems[position], true)
+                            mapView.setMapCenterPoint(mapView.poiItems[position].mapPoint, true)
+
+                        }
+
+                        override fun onPageScrollStateChanged(state: Int) {
+                            super.onPageScrollStateChanged(state)
+                        }
+                    })
+                }
+
+            }
+        }
+    }
+
+    override fun onMapViewInitialized(p0: MapView?) {
+
+    }
+
+    override fun onMapViewCenterPointMoved(p0: MapView?, p1: MapPoint?) {
+
+    }
+
+    override fun onMapViewZoomLevelChanged(p0: MapView?, p1: Int) {
+
+    }
+
+    override fun onMapViewSingleTapped(p0: MapView?, p1: MapPoint?) {
+        binding.viewPagerMap.visibility = View.GONE
+    }
+
+    override fun onMapViewDoubleTapped(p0: MapView?, p1: MapPoint?) {
+
+    }
+
+    override fun onMapViewLongPressed(p0: MapView?, p1: MapPoint?) {
+
+    }
+
+    override fun onMapViewDragStarted(p0: MapView?, p1: MapPoint?) {
+
+    }
+
+    override fun onMapViewDragEnded(p0: MapView?, p1: MapPoint?) {
+
+    }
+
+    override fun onMapViewMoveFinished(p0: MapView?, p1: MapPoint?) {
+
+    }
+
+    override fun onPOIItemSelected(p0: MapView?, p1: MapPOIItem?) {
+        mapView.setMapCenterPoint(p1?.mapPoint, true)
+        binding.viewPagerMap.visibility = View.VISIBLE
+        binding.viewPagerMap.currentItem = mapView.poiItems.indexOf(p1)
+    }
+
+    override fun onCalloutBalloonOfPOIItemTouched(p0: MapView?, p1: MapPOIItem?) {
+
+    }
+
+    override fun onCalloutBalloonOfPOIItemTouched(
+        p0: MapView?,
+        p1: MapPOIItem?,
+        p2: MapPOIItem.CalloutBalloonButtonType?
+    ) {
+
+    }
+
+    override fun onDraggablePOIItemMoved(p0: MapView?, p1: MapPOIItem?, p2: MapPoint?) {
+
     }
 }

--- a/app/src/main/java/com/pjm/cours/ui/map/MapActivity.kt
+++ b/app/src/main/java/com/pjm/cours/ui/map/MapActivity.kt
@@ -60,6 +60,16 @@ class MapActivity : AppCompatActivity(), MapViewEventListener, POIItemEventListe
         binding.viewPagerMap.adapter = adapter
     }
 
+    override fun onRestart() {
+        super.onRestart()
+        initMapView()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        binding.mapView.removeView(mapView)
+    }
+
     private fun setObserver() {
         viewModel.isCompleted.observe(this) { isCompleted ->
             if (isCompleted) {

--- a/app/src/main/java/com/pjm/cours/ui/map/MapViewModel.kt
+++ b/app/src/main/java/com/pjm/cours/ui/map/MapViewModel.kt
@@ -8,16 +8,55 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.pjm.cours.data.PostRepository
 import com.pjm.cours.data.model.Post
+import com.pjm.cours.util.Event
 import kotlinx.coroutines.launch
+import net.daum.mf.map.api.MapPoint
 
 class MapViewModel(
     private val repository: PostRepository
 ) : ViewModel() {
 
+    private val _isLoading = MutableLiveData<Event<Boolean>>()
+    val isLoading: LiveData<Event<Boolean>> = _isLoading
+
+    private val _isSettingOpened = MutableLiveData(Event(false))
+    val isSettingOpened: LiveData<Event<Boolean>> = _isSettingOpened
+
+    private val _isTrackingMode = MutableLiveData(Event(false))
+    val isTrackingMode: LiveData<Event<Boolean>> = _isTrackingMode
+
+    private val _currentMapPoint = MutableLiveData<Event<MapPoint>>()
+    val currentMapPoint: LiveData<Event<MapPoint>> = _currentMapPoint
+
+    private val _isGrantedPermission = MutableLiveData<Event<Boolean>>()
+    val isGrantedPermission: LiveData<Event<Boolean>> = _isGrantedPermission
+
     private val _isCompleted = MutableLiveData(false)
     val isCompleted: LiveData<Boolean> = _isCompleted
 
     var postList: List<Post>? = listOf()
+
+    fun setPermission(boolean: Boolean) {
+        _isGrantedPermission.value = Event(boolean)
+    }
+
+    fun openSetting(boolean: Boolean) {
+        _isSettingOpened.value = Event(boolean)
+    }
+
+    fun startTracking() {
+        _isTrackingMode.value = Event(true)
+    }
+
+    fun endTracking() {
+        _isTrackingMode.value = Event(false)
+    }
+
+    fun setCurrentMapPoint(currentMapPoint: MapPoint) {
+        _currentMapPoint.value = Event(currentMapPoint)
+        _isLoading.value = Event(false)
+    }
+
     fun getPosts() {
         viewModelScope.launch {
             val result = repository.getPostList()

--- a/app/src/main/java/com/pjm/cours/ui/map/MapViewModel.kt
+++ b/app/src/main/java/com/pjm/cours/ui/map/MapViewModel.kt
@@ -1,0 +1,37 @@
+package com.pjm.cours.ui.map
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.pjm.cours.data.PostRepository
+import com.pjm.cours.data.model.Post
+import kotlinx.coroutines.launch
+
+class MapViewModel(
+    private val repository: PostRepository
+) : ViewModel() {
+
+    private val _isCompleted = MutableLiveData(false)
+    val isCompleted: LiveData<Boolean> = _isCompleted
+
+    var postList: List<Post>? = listOf()
+    fun getPosts() {
+        viewModelScope.launch {
+            val result = repository.getPostList()
+            postList = result.body()?.values?.toList()
+            _isCompleted.value = true
+        }
+    }
+
+    companion object {
+
+        fun provideFactory(repository: PostRepository) = viewModelFactory {
+            initializer {
+                MapViewModel(repository)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/pjm/cours/ui/map/PostPreviewAdapter.kt
+++ b/app/src/main/java/com/pjm/cours/ui/map/PostPreviewAdapter.kt
@@ -1,0 +1,46 @@
+package com.pjm.cours.ui.map
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.pjm.cours.databinding.ItemPreviewBinding
+
+class PreviewAdapter : RecyclerView.Adapter<PreviewAdapter.PreViewHolder>() {
+
+    private val previewList = mutableListOf<String>()
+
+    class PreViewHolder(private val binding: ItemPreviewBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(preview: String) {
+            binding.tvTitlePreview.text = preview
+        }
+
+        companion object {
+
+            fun from(parent: ViewGroup): PreViewHolder {
+                val binding =
+                    ItemPreviewBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+                return PreViewHolder(binding)
+            }
+        }
+    }
+
+    fun submitList(items: List<String>) {
+        previewList.clear()
+        previewList.addAll(items)
+        notifyDataSetChanged()
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PreViewHolder {
+        return PreViewHolder.from(parent)
+    }
+
+    override fun getItemCount(): Int {
+        return previewList.size
+    }
+
+    override fun onBindViewHolder(holder: PreViewHolder, position: Int) {
+        holder.bind(previewList[position])
+    }
+}

--- a/app/src/main/java/com/pjm/cours/ui/postcomposition/PostCompositionActivity.kt
+++ b/app/src/main/java/com/pjm/cours/ui/postcomposition/PostCompositionActivity.kt
@@ -12,7 +12,7 @@ import com.google.android.material.datepicker.MaterialDatePicker
 import com.pjm.cours.CoursApplication
 import com.pjm.cours.R
 import com.pjm.cours.data.ItemStorage
-import com.pjm.cours.data.PostCompositionRepository
+import com.pjm.cours.data.PostRepository
 import com.pjm.cours.databinding.ActivityPostCompositionBinding
 import com.pjm.cours.ui.location.LocationActivity
 import com.pjm.cours.util.Constants
@@ -22,7 +22,7 @@ class PostCompositionActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityPostCompositionBinding
     private val viewModel: PostCompositionViewModel by viewModels {
-        PostCompositionViewModel.provideFactory(PostCompositionRepository(CoursApplication.apiContainer.provideApiClient()))
+        PostCompositionViewModel.provideFactory(PostRepository(CoursApplication.apiContainer.provideApiClient()))
     }
     private val startForResult = registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()

--- a/app/src/main/java/com/pjm/cours/ui/postcomposition/PostCompositionViewModel.kt
+++ b/app/src/main/java/com/pjm/cours/ui/postcomposition/PostCompositionViewModel.kt
@@ -3,13 +3,13 @@ package com.pjm.cours.ui.postcomposition
 import androidx.lifecycle.*
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
-import com.pjm.cours.data.PostCompositionRepository
+import com.pjm.cours.data.PostRepository
 import com.pjm.cours.util.Event
 import kotlinx.coroutines.launch
 import retrofit2.HttpException
 
 class PostCompositionViewModel(
-    private val repository: PostCompositionRepository
+    private val repository: PostRepository
 ) : ViewModel() {
 
     private val _isLoading = MutableLiveData(false)
@@ -134,7 +134,7 @@ class PostCompositionViewModel(
 
     companion object {
 
-        fun provideFactory(repository: PostCompositionRepository) = viewModelFactory {
+        fun provideFactory(repository: PostRepository) = viewModelFactory {
             initializer {
                 PostCompositionViewModel(repository)
             }

--- a/app/src/main/java/com/pjm/cours/ui/settinguserinfo/SettingUserInfoActivity.kt
+++ b/app/src/main/java/com/pjm/cours/ui/settinguserinfo/SettingUserInfoActivity.kt
@@ -18,7 +18,7 @@ import com.pjm.cours.CoursApplication
 import com.pjm.cours.data.UserRepository
 import com.pjm.cours.data.model.User
 import com.pjm.cours.databinding.ActivitySettingUserInfoBinding
-import com.pjm.cours.ui.MapActivity
+import com.pjm.cours.ui.map.MapActivity
 import com.pjm.cours.util.Constants
 
 class SettingUserInfoActivity : AppCompatActivity() {

--- a/app/src/main/res/drawable/baseline_group_24.xml
+++ b/app/src/main/res/drawable/baseline_group_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#000000"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M16,11c1.66,0 2.99,-1.34 2.99,-3S17.66,5 16,5c-1.66,0 -3,1.34 -3,3s1.34,3 3,3zM8,11c1.66,0 2.99,-1.34 2.99,-3S9.66,5 8,5C6.34,5 5,6.34 5,8s1.34,3 3,3zM8,13c-2.33,0 -7,1.17 -7,3.5L1,19h14v-2.5c0,-2.33 -4.67,-3.5 -7,-3.5zM16,13c-0.29,0 -0.62,0.02 -0.97,0.05 1.16,0.84 1.97,1.97 1.97,3.45L17,19h6v-2.5c0,-2.33 -4.67,-3.5 -7,-3.5z" />
+</vector>

--- a/app/src/main/res/drawable/baseline_location_on_24.xml
+++ b/app/src/main/res/drawable/baseline_location_on_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#000000"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,2C8.13,2 5,5.13 5,9c0,5.25 7,13 7,13s7,-7.75 7,-13c0,-3.87 -3.13,-7 -7,-7zM12,11.5c-1.38,0 -2.5,-1.12 -2.5,-2.5s1.12,-2.5 2.5,-2.5 2.5,1.12 2.5,2.5 -1.12,2.5 -2.5,2.5z" />
+</vector>

--- a/app/src/main/res/layout/activity_map.xml
+++ b/app/src/main/res/layout/activity_map.xml
@@ -20,6 +20,7 @@
             app:titleCentered="true" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
+            android:visibility="invisible"
             android:id="@+id/map_view"
             android:layout_width="0dp"
             android:layout_height="0dp"
@@ -31,6 +32,16 @@
             app:layout_constraintVertical_bias="1.0">
 
         </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <ProgressBar
+            android:id="@+id/progress_bar_map"
+            android:indeterminateTint="@color/orange"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/app_bar_map" />
 
         <androidx.viewpager2.widget.ViewPager2
             android:id="@+id/view_pager_map"

--- a/app/src/main/res/layout/activity_map.xml
+++ b/app/src/main/res/layout/activity_map.xml
@@ -6,7 +6,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".ui.MapActivity">
+        tools:context=".ui.map.MapActivity">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/app_bar_post_composition"

--- a/app/src/main/res/layout/activity_map.xml
+++ b/app/src/main/res/layout/activity_map.xml
@@ -9,7 +9,7 @@
         tools:context=".ui.map.MapActivity">
 
         <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/app_bar_post_composition"
+            android:id="@+id/app_bar_map"
             android:layout_width="0dp"
             android:layout_height="?attr/actionBarSize"
             app:layout_constraintEnd_toEndOf="parent"
@@ -18,6 +18,48 @@
             app:menu="@menu/top_app_bar_map"
             app:title="@string/label_post_map"
             app:titleCentered="true" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/map_view"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/app_bar_map"
+            app:layout_constraintVertical_bias="1.0">
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.viewpager2.widget.ViewPager2
+            android:id="@+id/view_pager_map"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
+        <androidx.cardview.widget.CardView
+            android:id="@+id/iv_my_location_map"
+            android:layout_width="42dp"
+            android:layout_height="42dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="16dp"
+            app:cardBackgroundColor="@color/white"
+            app:cardCornerRadius="42dp"
+            app:layout_constraintBottom_toTopOf="@id/view_pager_map"
+            app:layout_constraintEnd_toEndOf="parent">
+
+            <ImageView
+                android:contentDescription="@string/description_my_location_icon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                app:srcCompat="@drawable/baseline_my_location_24" />
+        </androidx.cardview.widget.CardView>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/item_preview.xml
+++ b/app/src/main/res/layout/item_preview.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <androidx.cardview.widget.CardView
+            android:layout_width="@dimen/viewpager_item_width"
+            android:layout_height="116dp"
+            android:layout_marginStart="@dimen/viewpager_item_margin"
+            app:cardCornerRadius="16dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <ImageView
+                    android:contentDescription="@string/description_host_profile_image"
+                    android:id="@+id/iv_host_profile_image"
+                    android:layout_width="70dp"
+                    android:layout_height="70dp"
+                    android:layout_marginStart="16dp"
+                    android:layout_marginTop="16dp"
+                    android:scaleType="centerCrop"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:srcCompat="@drawable/baseline_circle_24" />
+
+                <androidx.cardview.widget.CardView
+                    android:id="@+id/cv_category_preview"
+                    android:layout_width="56dp"
+                    android:layout_height="24dp"
+                    android:layout_marginStart="16dp"
+                    android:layout_marginTop="16dp"
+                    app:cardBackgroundColor="@color/grey"
+                    app:cardCornerRadius="8dp"
+                    app:layout_constraintStart_toEndOf="@+id/iv_host_profile_image"
+                    app:layout_constraintTop_toTopOf="parent">
+
+                    <TextView
+                        android:id="@+id/tv_category_preview"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:gravity="center"
+                        android:textStyle="bold"
+                        app:layout_constraintStart_toEndOf="@+id/iv_host_profile_image"
+                        app:layout_constraintTop_toTopOf="parent"
+                        tools:text="카테고리" />
+                </androidx.cardview.widget.CardView>
+
+                <androidx.cardview.widget.CardView
+                    android:id="@+id/cv_language_preview"
+                    android:layout_width="56dp"
+                    android:layout_height="24dp"
+                    android:layout_marginStart="8dp"
+                    android:layout_marginTop="16dp"
+                    app:cardBackgroundColor="@color/grey"
+                    app:cardCornerRadius="8dp"
+                    app:layout_constraintStart_toEndOf="@+id/cv_category_preview"
+                    app:layout_constraintTop_toTopOf="parent">
+
+                    <TextView
+                        android:id="@+id/tv_language_preview"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:gravity="center"
+                        android:textStyle="bold"
+                        app:layout_constraintStart_toEndOf="@+id/iv_host_profile_image"
+                        app:layout_constraintTop_toTopOf="parent"
+                        tools:text="언어" />
+                </androidx.cardview.widget.CardView>
+
+
+                <TextView
+                    android:id="@+id/tv_title_preview"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="16dp"
+                    android:layout_marginTop="8dp"
+                    android:textSize="16sp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@+id/iv_host_profile_image"
+                    app:layout_constraintTop_toBottomOf="@+id/cv_category_preview"
+                    tools:text="모임 제목" />
+
+                <ImageView
+                    android:contentDescription="@string/description_distance_icon"
+                    android:id="@+id/iv_distance_icon_preview"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="12dp"
+                    android:layout_marginTop="8dp"
+                    app:layout_constraintStart_toEndOf="@+id/iv_host_profile_image"
+                    app:layout_constraintTop_toBottomOf="@+id/tv_title_preview"
+                    app:srcCompat="@drawable/baseline_location_on_24" />
+
+                <TextView
+                    android:id="@+id/tv_distance_preview"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    app:layout_constraintBottom_toBottomOf="@+id/iv_distance_icon_preview"
+                    app:layout_constraintStart_toEndOf="@+id/iv_distance_icon_preview"
+                    tools:text="거리" />
+
+                <ImageView
+                    android:contentDescription="@string/description_current_people_icon"
+                    android:id="@+id/iv_current_people_icon"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:layout_marginTop="9dp"
+                    app:layout_constraintStart_toEndOf="@+id/tv_distance_preview"
+                    app:layout_constraintTop_toBottomOf="@+id/tv_title_preview"
+                    app:srcCompat="@drawable/baseline_group_24" />
+
+                <TextView
+                    android:id="@+id/tv_current_people_preview"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="5dp"
+                    app:layout_constraintBottom_toBottomOf="@+id/iv_current_people_icon"
+                    app:layout_constraintStart_toEndOf="@+id/iv_current_people_icon"
+                    tools:text="현재인원/전체인원" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.cardview.widget.CardView>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -10,5 +10,6 @@
     <color name="orange">#FD9347</color>
     <color name="colorButtonDisabled">#D9D9D9</color>
     <color name="dialogBackground">#D9D9D9</color>
+    <color name="grey">#D9D9D9</color>
     <color name="grey_transparent">#AA616161</color>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="viewpager_item_width">330dp</dimen>
+    <dimen name="viewpager_item_margin">16dp</dimen>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,4 +25,8 @@
     <string name="description_meeting_date_icon">날짜 선택 아이콘</string>
     <string name="description_category_icon">카테고리 선택 아이콘</string>
     <string name="description_language_icon">언어 선택 아이콘</string>
+    <string name="description_host_profile_image">모임 호스트 프로필</string>
+    <string name="description_my_location_icon">내 위치로 이동하는 아이콘</string>
+    <string name="description_distance_icon">나와 모임 위치 사이 거리</string>
+    <string name="description_current_people_icon">현재 모임 인원</string>
 </resources>


### PR DESCRIPTION
[작업 내용]
모임 지도 레이아웃 구현
 - Kakao map에 파이어베이스에 저장된 모임 게시글 요청
 - 성공 응답시 로딩창 없애고, 지도위에 마커 표시
 - ViewPager2를 활용하여 화면 하단에 모임 미리보기 화면 스와이프 구현
 - 뷰페이저 스와이프시 해당 마커가 지도 중앙에 표시
 - 마커 선택시 해당 모임 미리보기가 뷰페이저에 표시
 - 위치 권한 로직 요청( 사용자 권한 거부 대응)
 - 지도위에 현재 위치 표시 기능 구현
 - Kakao mapView 두개 생성시 발생하는 오류 대응
 
[다음 작업]
- 네트워크 요청 반환 타입 정의
- ui 상태에 맞게 데이터 변환
- 모임 미리보기 선택시 해당 모임 상세 화면으로 이동
- 코드 분리