### PR TITLE
fix: 모임 지도 화면 : 네트워크 미연결 후 다시 연결시 미연결 메시지 에러 개선

### DIFF
--- a/app/src/main/java/com/pjm/cours/data/repository/UserRepository.kt
+++ b/app/src/main/java/com/pjm/cours/data/repository/UserRepository.kt
@@ -73,6 +73,7 @@ class UserRepository @Inject constructor(
     }
 
     fun getUserInfo(
+        onComplete: () -> Unit,
         onSuccess: () -> Unit,
         onError: () -> Unit,
     ) = flow {
@@ -99,7 +100,7 @@ class UserRepository @Inject constructor(
             onError()
         }
     }.onCompletion {
-        onSuccess()
+        onComplete()
     }.flowOn(Dispatchers.Default)
 
     private suspend fun getDownLoadImageUri(hostImageUri: String) =

--- a/app/src/main/java/com/pjm/cours/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/pjm/cours/ui/login/LoginViewModel.kt
@@ -20,6 +20,7 @@ class LoginViewModel @Inject constructor(
     fun getUserInfo() {
         viewModelScope.launch {
             userRepository.getUserInfo(
+                onComplete = { },
                 onSuccess = { },
                 onError = {
                     viewModelScope.launch {

--- a/app/src/main/java/com/pjm/cours/ui/map/MapViewModel.kt
+++ b/app/src/main/java/com/pjm/cours/ui/map/MapViewModel.kt
@@ -84,6 +84,7 @@ class MapViewModel @Inject constructor(
         repository.getPostList(
             onSuccess = {
                 _isLoading.value = false
+                _isError.value = false
             }, onError = {
                 _isLoading.value = false
                 _isError.value = true

--- a/app/src/main/java/com/pjm/cours/ui/map/MapViewModel.kt
+++ b/app/src/main/java/com/pjm/cours/ui/map/MapViewModel.kt
@@ -22,8 +22,8 @@ class MapViewModel @Inject constructor(
     private val _isGrantedPermission = MutableSharedFlow<Boolean>()
     val isGrantedPermission = _isGrantedPermission.asSharedFlow()
 
-    private val _isError = MutableStateFlow(false)
-    val isError = _isError.asStateFlow()
+    private val _isError = MutableSharedFlow<Boolean>()
+    val isError = _isError.asSharedFlow()
 
     private val _isLoading = MutableStateFlow(true)
     val isLoading = _isLoading.asStateFlow()
@@ -84,10 +84,11 @@ class MapViewModel @Inject constructor(
         repository.getPostList(
             onSuccess = {
                 _isLoading.value = false
-                _isError.value = false
             }, onError = {
                 _isLoading.value = false
-                _isError.value = true
+                viewModelScope.launch {
+                    _isError.emit(true)
+                }
             }).collect { postList ->
             _postPreviewList.value = postList.map { post ->
                 PostPreview(
@@ -120,7 +121,9 @@ class MapViewModel @Inject constructor(
                 _isLoading.value = false
             }, onError = {
                 _isLoading.value = false
-                _isError.value = true
+                viewModelScope.launch{
+                    _isError.emit(true)
+                }
             }).collect { postList ->
             _postPreviewList.value = postList.map { post ->
                 PostPreview(

--- a/app/src/main/java/com/pjm/cours/ui/postlist/PostListFragment.kt
+++ b/app/src/main/java/com/pjm/cours/ui/postlist/PostListFragment.kt
@@ -29,6 +29,7 @@ class PostListFragment : BaseFragment<FragmentPostListBinding>(R.layout.fragment
     }
 
     private fun setLayout() {
+        viewModel.refreshPostList()
         setAppBar()
         setPostList()
         setErrorMessage()

--- a/app/src/main/java/com/pjm/cours/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/pjm/cours/ui/profile/ProfileFragment.kt
@@ -1,7 +1,6 @@
 package com.pjm.cours.ui.profile
 
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
@@ -27,6 +26,7 @@ class ProfileFragment : BaseFragment<FragmentProfileBinding>(R.layout.fragment_p
     }
 
     private fun setLayout() {
+        viewModel.refreshUserInfo()
         setErrorMessage()
         setAppBar()
     }

--- a/app/src/main/java/com/pjm/cours/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/pjm/cours/ui/profile/ProfileViewModel.kt
@@ -6,6 +6,7 @@ import com.pjm.cours.data.model.User
 import com.pjm.cours.data.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -16,25 +17,36 @@ class ProfileViewModel @Inject constructor(
     private val _isLoading = MutableStateFlow(true)
     val isLoading = _isLoading.asStateFlow()
 
-    private val _isError = MutableStateFlow(false)
-    val isError = _isError.asStateFlow()
+    private val _isError = MutableSharedFlow<Boolean>()
+    val isError = _isError.asSharedFlow()
 
-    val userInfo: StateFlow<User> = getUserInfo().stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(5000),
-        initialValue = User()
-    )
-
-    private fun getUserInfo() = userRepository.getUserInfo(
-        onSuccess = { _isLoading.value = false },
-        onError = {
-            _isLoading.value = false
-            _isError.value = true
-        }
-    )
+    private val _userInfo = MutableStateFlow(User())
+    val userInfo: StateFlow<User> = _userInfo.asStateFlow()
 
     fun logOut() {
         userRepository.logOut()
+    }
+
+    fun refreshUserInfo() {
+        _isLoading.value = true
+        viewModelScope.launch {
+            userRepository.getUserInfo(
+                onComplete = {
+                    _isLoading.value = false
+                },
+                onSuccess = {
+
+                },
+                onError = {
+                    _isLoading.value = false
+                    viewModelScope.launch {
+                        _isError.emit(true)
+                    }
+                }
+            ).collect { user ->
+                _userInfo.value = user
+            }
+        }
     }
 
 }


### PR DESCRIPTION
- 네트워크 미연결 상태에서  화면에 들어가면 네트워크 실패로 인한 에러 메시지를 띄워준다.
- 다시 네트워크 연결 후 화면에 갔을시, 계속 네트워크 미연결 에러메시지를 띄어주는 에러가 발생하고 있다.

- SharedState를 활용하여 에러 상태를 관리하지 않고 이벤트 발생시 처리하는 로직으로 변경